### PR TITLE
Fixes to address Ken's review

### DIFF
--- a/afrikaans/body/study_components.tex
+++ b/afrikaans/body/study_components.tex
@@ -61,7 +61,7 @@
                 & \qquad Voorwaardelike Lus (While Lus)        &    &    \\
                 & \qquad Vertakking (If, Elif, Else)           &    &    \\
              \hline
-             4  & Probleemoplossing                            & 36 & 8  \\
+             4  & Probleemoplossing                            & 35 & 8  \\
                 & \qquad Probleem kompleksiteit afbreek        &    &    \\
                 & \qquad Vereenvoudigings met Funksies         &    &    \\
                 & \qquad Geneste Stellings                     &    &    \\
@@ -79,7 +79,7 @@
                 & \qquad Gevorderde Ingeboude Funksies         &    &    \\
              \hline
              8  & Grafiese Gebruikerskoppelvlakke              &  5 & 2  \\
-                & \qquad TKinter Module                        &    &    \\
+                & \qquad Tkinter Module                        &    &    \\
                 & \qquad Vorms en Vormvoorwerpe                &    &    \\
                 & \qquad Muis en Sleutelbord Gebeure           &    &    \\
              \hline
@@ -101,36 +101,38 @@
         gebruik van hierdie plan om seker te maak dat jy nie agter raak nie in
         terme van die lesings en tutoriale nie.
 
-        Tabel~\ref{tab:lec_plan} sit uiteen hoe die studietemas deur die loop
-        van die semester sal volg.  Elke week het `n ooreenstemmende tutoriaal
-        wat deur die loop van die week voltooi en teen die	einde van die week
-        ingehanding moet word. Die tutoriaalsessies is om die studente te help
-        om die materiaal te bemeester om sodoende die tutoriale te kan voltooi.
+        Tabel~\ref{tab:lec_plan} sit uiteen die aantal lesings\footnote{Die
+        aantal Engels/Afrikaans lesings elke week} elke week en hoe die
+        studietemas deur die loop van die semester sal volg. Elke week het `n
+        ooreenstemmende tutoriaal wat deur die loop van die week voltooi en
+        teen die einde van die week ingehanding moet word. Die
+        tutoriaalsessies is om die studente te help om die materiaal te
+        bemeester om sodoende die tutoriale te kan voltooi.
 
         \begin{table}[!h]
             \begin{center}
              \begin{tabular}{|l|l|l|l|l|}
                  \hline
-                 {\bf Week} & {\bf Lesings} & {\bf Datums} & {\bf Studie Tema}
-                 & {\bf Tutoriaal} \\
+                 {\bf Week} & {\bf Lesings} & {\bf Datums} & %
+                 {\bf Studie Tema} & {\bf Tutoriaal} \\
                  \hline
-                 1  & 4     &  6 –- 10 Feb      & 1, 2  & Geen \\
-                 2  & 4     & 13 –- 17 Feb      & 3     & T1 \\
-                 3  & 4     & 20 –- 24 Feb      & 4     & T2 \\
-                 4  & 4     & 27 –-  3 Mar      & 4     & T3 \\
-                 5  & 4     &  6 –- 10 Mar      & 4, 5  & T4 \\
+                 1  & 4/4   &  6 –- 10 Feb      & 1, 2  & Geen \\
+                 2  & 4/4   & 13 –- 17 Feb      & 3     & T1 \\
+                 3  & 4/4   & 20 –- 24 Feb      & 4     & T2 \\
+                 4  & 4/4   & 27 –-  3 Mar      & 4     & T3 \\
+                 5  & 4/4   &  6 –- 10 Mar      & 4, 5  & T4 \\
                     &       & == TOETSWEEK 1 == &       & \\
-                 6  & 2     & 22 -- 24 Mar      & 5     & T5 \\
-                 7  & 4     & 27 -- 31 Mar      & 5     & T6 \\
-                 8  & 4     &  3 --  7 Apr      & 6     & T7 \\
+                 6  & 2/2   & 22 -- 24 Mar      & 5     & T5 \\
+                 7  & 4/4   & 27 -- 31 Mar      & 5     & T6 \\
+                 8  & 4/4   &  3 --  7 Apr      & 6     & T7 \\
                     &       & ==== RECESS ====  &       & \\
-                 9  & 2 / 0 & 19 -- 21 Apr      & 10    & T8 \\
-                 10 & 2 / 4 & 24 -- 26 Apr      & 10    & T8 \\
-                 11 & 4     &  2 --  5 Mei      & 10    & T9 \\
+                 9  & 2/0   & 19 -- 21 Apr      & 10    & T8 \\
+                 10 & 2/4   & 24 -- 26 Apr      & 10    & T8 \\
+                 11 & 4/4   &  2 --  5 Mei      & 10    & T9 \\
                     &       & == TOETSWEEK 2 == &       & \\
-                 12 & 4     & 15 -- 19 Mei      & 7, 8  & T10 \\
-                 13 & 4     & 22 -- 26 Mei      & 8, 9  & T11 \\
-                 14 & 2     & 29 -- 30 Mei      & Herhaling & T12 \\
+                 12 & 4/4   & 15 -- 19 Mei      & 7, 8  & T10 \\
+                 13 & 4/4   & 22 -- 26 Mei      & 8, 9  & T11 \\
+                 14 & 2/2   & 29 -- 30 Mei      & Herhaling & T12 \\
                     &       & ===== EKSAMEN ===== &       & \\
                  \hline
              \end{tabular}

--- a/afrikaans/body/study_material.tex
+++ b/afrikaans/body/study_material.tex
@@ -14,7 +14,7 @@
         ``\underline{Python for Computational Science and Engineering}'' deur
         Hans Fangohr
 
-    \subsection{Lecture Notes}
+    \subsection{Lesingnotas}
         Let op dat ons die onderskeiding make tussen die \textbf{studienotas}
         wat hierbo bespreek is en die \textbf{lesingnotas} wat hier bespreek
         is. Hierdie lesingnotas sal ook deel van die sillabus wees en is

--- a/english/body/study_components.tex
+++ b/english/body/study_components.tex
@@ -64,7 +64,7 @@
                 & \qquad Conditional Looping (While Loop)    &    &    \\
                 & \qquad Branching (If, Elif, Else)          &    &    \\
              \hline
-             5  & Solving Problems                           & 36 & 8  \\
+             5  & Solving Problems                           & 35 & 8  \\
                 & \qquad Breaking Down Problem Complexity    &    &    \\
                 & \qquad Use of Functions (Simplification)   &    &    \\
                 & \qquad Nested Statements                   &    &    \\
@@ -82,11 +82,11 @@
                 & \qquad Advanced Built-In Functions         &    &    \\
              \hline
              9  & Graphical User Interfaces (GUI's)          &  5 & 2  \\
-                & \qquad TKinter Module                      &    &    \\
+                & \qquad Tkinter Module                      &    &    \\
                 & \qquad Forms and Form Objects              &    &    \\
                 & \qquad Mouse / Keyboard Events             &    &    \\
              \hline
-             10 & Spreadsheets                               & 39 & 8  \\
+             10 & Spreadsheets                               & 30 & 8  \\
                 & \qquad Formulas and Calculations           &    &    \\
                 & \qquad Spreadsheet Detective               &    &    \\
                 & \qquad Plotting and Graphs                 &    &    \\
@@ -105,10 +105,11 @@
         lectures and/or tutorials. There are a total of 48 lectures and 12
         tutorial sessions over the 14 weeks of the semester.
 
-        Table \ref{tab:lec_plan} lists which study themes will be covered
-        in which weeks of the semester. Each week has a corresponding tutorial
-        which should be completed during the specific week in the tutorial
-        sessions.
+        Table \ref{tab:lec_plan} lists the number of lectures\footnote{Number
+        of English/Afrikaans lectures per week} per week and which study themes
+        will be covered in which weeks of the semester. Each week has a
+        corresponding tutorial which should be completed during the specific
+        week in the tutorial sessions.
 
         \begin{table}[!h]
             \begin{center}
@@ -117,23 +118,23 @@
                  {\bf Week} & {\bf Lectures} & {\bf Dates} & %
                  {\bf Study Theme} & {\bf Tutorial} \\
                  \hline
-                 1  & 4     &  6 –- 10 Feb      & 1, 2  & None \\
-                 2  & 4     & 13 –- 17 Feb      & 3     & T1 \\
-                 3  & 4     & 20 –- 24 Feb      & 4     & T2 \\
-                 4  & 4     & 27 –-  3 Mar      & 4     & T3 \\
-                 5  & 4     &  6 –- 10 Mar      & 4, 5  & T4 \\
+                 1  & 4/4   &  6 –- 10 Feb      & 1, 2  & None \\
+                 2  & 4/4   & 13 –- 17 Feb      & 3     & T1 \\
+                 3  & 4/4   & 20 –- 24 Feb      & 4     & T2 \\
+                 4  & 4/4   & 27 –-  3 Mar      & 4     & T3 \\
+                 5  & 4/4   &  6 –- 10 Mar      & 4, 5  & T4 \\
                     &       & == TESTWEEK 1 == &       & \\
-                 6  & 2     & 22 -- 24 Mar      & 5     & T5 \\
-                 7  & 4     & 27 -- 31 Mar      & 5     & T6 \\
-                 8  & 4     &  3 --  7 Apr      & 6     & T7 \\
+                 6  & 2/2   & 22 -- 24 Mar      & 5     & T5 \\
+                 7  & 4/4   & 27 -- 31 Mar      & 5     & T6 \\
+                 8  & 4/4   &  3 --  7 Apr      & 6     & T7 \\
                     &       & ==== RECESS ==== &       & \\
-                 9  & 2 / 0 & 19 -- 21 Apr      & 10    & T8 \\
-                 10 & 2 / 4 & 24 -- 26 Apr      & 10    & T8 \\
-                 11 & 4     &  2 --  5 Mey      & 10    & T9 \\
+                 9  & 2/0   & 19 -- 21 Apr      & 10    & T8 \\
+                 10 & 2/4   & 24 -- 26 Apr      & 10    & T8 \\
+                 11 & 4/4   &  2 --  5 May      & 10    & T9 \\
                     &       & == TESTWEEK 2 == &       & \\
-                 12 & 4     & 15 -- 19 Mey      & 7, 8  & T10 \\
-                 13 & 4     & 22 -- 26 Mey      & 8, 9  & T11 \\
-                 14 & 2     & 29 -- 30 Mey      & Recap & T12 \\
+                 12 & 4/4   & 15 -- 19 May      & 7, 8  & T10 \\
+                 13 & 4/4   & 22 -- 26 May      & 8, 9  & T11 \\
+                 14 & 2/2   & 29 -- 30 May      & Recap & T12 \\
                     &       & ===== EXAM ===== &       & \\
                  \hline
              \end{tabular}


### PR DESCRIPTION
>English:
two errata:
May spelt as Mey in Tab.5 (4 occurrences)
TKinter should be Tkinter in Tab.4
Notional hours in Tab.4 add up to 170 hours, not 160!
What does 2/0 and 2/4 Lectures indicate for Week 9-10? Different groups?


>Afrikaans:
Inhoud: 5.3 Lecture Notes should be Lesingnotas. Also heading on p.9
ook TKinter in Tab.4
Leerure in Tab.4 tel op na 161 ure, nie 160 nie (Tema no 10 - 30 ure, in English = 39 hours!)
Sien Tab.5 opmerking bo oor 2/0, 2/4